### PR TITLE
Trying to run alongside the Cryptid mod causes a crash

### DIFF
--- a/lovely/joker_functionality.toml
+++ b/lovely/joker_functionality.toml
@@ -17,22 +17,6 @@ position = "before"
 payload = '''
 if next(SMODS.find_card('j_nacho_gallade')) and card.ability.set == 'Planet' then
     return true
-else
-'''
-match_indent = true
-
-
-[[patches]]
-[patches.pattern]
-target = "functions/common_events.lua"
-pattern = '''
-    G.E_MANAGER:add_event(Event({
-            trigger = 'immediate',
-            func = (function() check_for_unlock{type = 'upgrade_hand', hand = hand, level = G.GAME.hands[hand].level} return true end)
-        }))
-'''
-position = "after"
-payload = '''
 end
 '''
 match_indent = true


### PR DESCRIPTION
The lovely patch in question wraps the inside of the function in one big if/else block which is butting heads with Cryptid also trying to patch it, but if the `if` is true it returns early. So I've commited to the 'early out' pattern and just made it a self contained if statement.

The tldr; I replaced `else` with `end` and now I can get to the splash screen. I am not as experienced with your Gallade line and I remember it being fiddly, so this might need some testing before it's accepted.